### PR TITLE
Partially revert misguided DOF code that raised min radius for formation

### DIFF
--- a/Rising Stars/scripts/server/orders/LeaderAI.as
+++ b/Rising Stars/scripts/server/orders/LeaderAI.as
@@ -1462,10 +1462,21 @@ tidy class LeaderAI : Component_LeaderAI, Savable {
 
 		calculateSightRange(obj);
 		formation.reset(obj.radius * 2.0, getFormationRadius(obj));
-		// BEGIN NON-MIT CODE - DOF
-		// Increased min radius for supports that are larger than ourselves.
-		formation.reset(obj.radius * 3.0, getFormationRadius(obj));
-		// END NON-MIT CODE
+
+		double minRad;
+		if(obj.isPlanet) {
+			// Planets have such a large radius taking multiples of it
+			// will exceed the maxRad calculation which makes the formation
+			// have a min radius higher than the max - ie no actual space
+			// for supports at all.
+			minRad = obj.radius + 2.0;
+		} else {
+			// BEGIN NON-MIT CODE - DOF
+			// Increased min radius for supports that are larger than ourselves.
+			minRad = obj.radius * 3.0;
+			// END NON-MIT CODE
+		}
+		formation.reset(minRad, getFormationRadius(obj));
 		leaderChangeOwner(obj, null, obj.owner);
 
 		AllowFillFrom = obj.isPlanet;
@@ -1650,10 +1661,19 @@ tidy class LeaderAI : Component_LeaderAI, Savable {
 		//Refresh formations
 		if(formationDelta && !obj.inCombat) {
 			if(!obj.hasMover || !obj.isMoving) {
-				// BEGIN NON-MIT CODE - DOF
-				// Increasing radius for supports larger than flagship
-				double minRad = obj.radius * 3.0;
-				// END NON-MIT CODE
+				double minRad;
+				if(obj.isPlanet) {
+					// Planets have such a large radius taking multiples of it
+					// will exceed the maxRad calculation which makes the formation
+					// have a min radius higher than the max - ie no actual space
+					// for supports at all.
+					minRad = obj.radius + 2.0;
+				} else {
+					// BEGIN NON-MIT CODE - DOF
+					// Increasing radius for supports larger than flagship
+					minRad = obj.radius * 3.0;
+					// END NON-MIT CODE
+				}
 				double maxRad = getFormationRadius(obj);
 				formation.reset(minRad, maxRad);
 				for(uint i = 0, cnt = supports.length; i < cnt; ++i) {


### PR DESCRIPTION
This code was clearly not written with ringworld planets in mind, so now it only applies to ships, orbitals and stations. Restored vanilla radius calculation for planets (which will be covered under MIT license, so moved the non MIT code blocks a little).